### PR TITLE
Updated makefile and fixed compiler warnings

### DIFF
--- a/makefile
+++ b/makefile
@@ -14,7 +14,7 @@ OBJECTS = $(patsubst %.c, %.o, $(wildcard $(SOURCEDIR)*.c))
 HEADERS = $(wildcard $(INCLUDEDIR),*.h)
 
 %.o: %.c $(HEADERS)
-	$(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) -c $< -o $@ -I $(INCLUDEDIR)
 
 .PRECIOUS: $(TARGET) $(OBJECTS)
 

--- a/source/cascoda_api.c
+++ b/source/cascoda_api.c
@@ -1395,6 +1395,7 @@ uint8_t TDME_GetTxPower(
 int cascoda_register_callbacks(struct cascoda_api_callbacks *in_callbacks)
 {
 	memcpy(&callbacks, in_callbacks, sizeof(struct cascoda_api_callbacks));
+	return 0;
 }
 
 int cascoda_downstream_dispatch(const uint8_t *buf, size_t len)
@@ -1490,7 +1491,7 @@ int cascoda_downstream_dispatch(const uint8_t *buf, size_t len)
 	case SPI_TDME_MESSAGE_INDICATION:
 		if (callbacks.TDME_MESSAGE_indication) {
 			return callbacks.TDME_MESSAGE_indication(
-				buf + 2,
+				(char *)(buf + 2),
 				len
 			);
 		}

--- a/source/cascoda_debug.c
+++ b/source/cascoda_debug.c
@@ -89,7 +89,7 @@ void dpFlush(void *pDeviceRef)
 {
 	if (PutcCount != 0) {
 		if (EVBME_Message != NULL) {
-			EVBME_Message(PutcBuffer, PutcCount, pDeviceRef);
+			EVBME_Message((char *)PutcBuffer, PutcCount, pDeviceRef);
 		}
 		PutcCount = 0;
 	}

--- a/source/cascoda_evbme.c
+++ b/source/cascoda_evbme.c
@@ -49,7 +49,7 @@ uint8_t EVBME_SetVal[8] = {0, 0, 0, 0, 0, 0, 0, 0};
 /******************************************************************************/
 int EVBMEInitialise(char *version, void *pDeviceRef)
 {
-	int status;
+	int status = 0;
 
 	EVBME_SetVal[0] = 1;             // initialise/reset PIBs on higher layers
 


### PR DESCRIPTION
Following a previous change to the #includes, the included makefile was broken. This has been fixed, along with the few small compile warnings that were being generated.